### PR TITLE
Revamp jump rope training landing page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,1003 @@
+:root {
+    --color-primary: #0b4fff;
+    --color-accent: #ff7a45;
+    --color-deep: #061c58;
+    --color-muted: #5c6784;
+    --color-line: #e6e9f2;
+    --color-surface: #f5f7ff;
+    --font-family: 'Manrope', 'Source Han Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+    --container-width: min(1080px, calc(100% - 32px));
+    --radius-lg: 24px;
+    --radius-md: 16px;
+    --radius-sm: 12px;
+    --shadow-soft: 0 16px 40px rgba(10, 32, 86, 0.08);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-family);
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--color-deep);
+    background: #ffffff;
+}
+
+img, video {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    border-radius: var(--radius-md);
+}
+
+video {
+    box-shadow: var(--shadow-soft);
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--color-primary);
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 8px;
+    background: #fff;
+    color: var(--color-deep);
+    padding: 8px 16px;
+    border-radius: var(--radius-sm);
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    top: 8px;
+}
+
+.container {
+    width: var(--container-width);
+    margin: 0 auto;
+}
+
+.section {
+    padding: 80px 0;
+}
+
+.section--tight {
+    padding-top: 96px;
+    padding-bottom: 80px;
+}
+
+.section--light {
+    background: var(--color-surface);
+}
+
+.section--accent {
+    background: #061c58;
+    color: #ffffff;
+}
+
+.section__header {
+    text-align: center;
+    margin-bottom: 48px;
+    display: grid;
+    gap: 16px;
+}
+
+.section__header--left {
+    text-align: left;
+    justify-items: start;
+}
+
+.eyebrow {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+}
+
+.section--accent .eyebrow,
+.section--accent .section__header p {
+    color: rgba(255, 255, 255, 0.72);
+}
+
+h1, h2, h3 {
+    margin: 0;
+    font-weight: 700;
+}
+
+h1 {
+    font-size: clamp(32px, 6vw, 48px);
+    line-height: 1.2;
+}
+
+h2 {
+    font-size: clamp(28px, 4vw, 40px);
+    line-height: 1.25;
+}
+
+h3 {
+    font-size: 22px;
+}
+
+.lead {
+    font-size: 18px;
+    color: var(--color-muted);
+}
+
+.section--accent .lead {
+    color: rgba(255, 255, 255, 0.84);
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 24px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 16px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
+}
+
+.btn--primary {
+    background: var(--color-primary);
+    color: #ffffff;
+    box-shadow: 0 12px 24px rgba(11, 79, 255, 0.24);
+}
+
+.btn--primary:hover,
+.btn--primary:focus-visible {
+    background: #0732b9;
+}
+
+.btn--ghost {
+    background: #ffffff;
+    border-color: rgba(11, 79, 255, 0.24);
+    color: var(--color-primary);
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus-visible {
+    background: rgba(11, 79, 255, 0.08);
+}
+
+.btn--light {
+    background: #ffffff;
+    color: var(--color-deep);
+}
+
+.btn--light:hover,
+.btn--light:focus-visible {
+    background: rgba(255, 255, 255, 0.88);
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 900;
+    backdrop-filter: blur(12px);
+    background: rgba(255, 255, 255, 0.92);
+    border-bottom: 1px solid rgba(6, 28, 88, 0.08);
+}
+
+.navbar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 0;
+    gap: 16px;
+}
+
+.logo img {
+    display: block;
+}
+
+.nav-links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 16px;
+    align-items: center;
+}
+
+.nav-links a {
+    font-size: 15px;
+    font-weight: 500;
+    padding: 8px 12px;
+    border-radius: 999px;
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
+    background: rgba(11, 79, 255, 0.1);
+    color: var(--color-primary);
+}
+
+.nav-toggle {
+    display: none;
+    background: transparent;
+    border: none;
+    padding: 8px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.nav-toggle span {
+    display: block;
+    width: 24px;
+    height: 2px;
+    background: var(--color-deep);
+    margin: 5px 0;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.hero {
+    background: linear-gradient(180deg, #ffffff 0%, #eef3ff 100%);
+}
+
+.hero__layout {
+    display: grid;
+    gap: 48px;
+    align-items: center;
+}
+
+.hero__content {
+    display: grid;
+    gap: 24px;
+}
+
+.hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.hero__promises {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: 14px;
+    color: var(--color-muted);
+}
+
+.hero__promises span {
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(6, 28, 88, 0.08);
+}
+
+.hero__meta {
+    display: grid;
+    gap: 24px;
+    align-items: center;
+}
+
+.hero__qr {
+    display: grid;
+    gap: 12px;
+    justify-items: center;
+    text-align: center;
+    font-size: 14px;
+    color: var(--color-muted);
+}
+
+.metrics {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+}
+
+.metrics__item {
+    background: #ffffff;
+    border-radius: var(--radius-md);
+    padding: 16px 20px;
+    min-width: 152px;
+    box-shadow: var(--shadow-soft);
+}
+
+.metrics__value {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--color-primary);
+}
+
+.metrics__label {
+    display: block;
+    font-size: 14px;
+    color: var(--color-muted);
+}
+
+.hero__media {
+    display: grid;
+    gap: 24px;
+}
+
+.hero__gallery {
+    display: grid;
+    gap: 16px;
+}
+
+.hero__gallery figure {
+    margin: 0;
+    overflow: hidden;
+    border-radius: var(--radius-md);
+}
+
+.hero__gallery img {
+    width: 100%;
+    height: auto;
+    transition: transform 0.4s ease;
+}
+
+.hero__gallery img:hover {
+    transform: scale(1.06);
+}
+
+.hero__video {
+    display: grid;
+    gap: 12px;
+}
+
+.video__caption {
+    margin: 0;
+    font-size: 14px;
+    color: var(--color-muted);
+    text-align: center;
+}
+
+.grid {
+    display: grid;
+    gap: 24px;
+}
+
+.grid--three {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.tile {
+    background: #ffffff;
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    display: grid;
+    gap: 16px;
+    box-shadow: var(--shadow-soft);
+}
+
+.tile ul {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--color-muted);
+}
+
+.pricing-grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.plan {
+    background: #ffffff;
+    border-radius: var(--radius-lg);
+    padding: 32px 24px;
+    display: grid;
+    gap: 16px;
+    border: 1px solid rgba(6, 28, 88, 0.08);
+}
+
+.plan ul {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--color-muted);
+}
+
+.plan--highlight {
+    border: 2px solid var(--color-primary);
+    box-shadow: var(--shadow-soft);
+}
+
+.plan__badge {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: rgba(11, 79, 255, 0.08);
+    color: var(--color-primary);
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.plan__price {
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0;
+}
+
+.fine-print {
+    margin-top: 32px;
+    font-size: 14px;
+    color: var(--color-muted);
+    text-align: center;
+}
+
+.proof {
+    display: grid;
+    gap: 32px;
+    align-items: start;
+}
+
+.proof__summary {
+    background: #ffffff;
+    padding: 32px;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
+    display: grid;
+    gap: 24px;
+}
+
+.kpi {
+    display: grid;
+    gap: 16px;
+}
+
+.kpi div {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 16px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.kpi dd {
+    margin: 0;
+    color: var(--color-primary);
+}
+
+.kpi dt {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.proof__details {
+    display: grid;
+    gap: 24px;
+}
+
+.testimonials {
+    display: grid;
+    gap: 16px;
+}
+
+.testimonials article {
+    background: #ffffff;
+    padding: 24px;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
+}
+
+.testimonial__meta {
+    margin: 16px 0 0;
+    font-size: 14px;
+    color: var(--color-muted);
+}
+
+.logos {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 16px;
+    align-items: center;
+    justify-items: center;
+}
+
+.logos img {
+    filter: grayscale(100%);
+    opacity: 0.8;
+}
+
+.steps {
+    list-style: none;
+    display: grid;
+    gap: 24px;
+    margin: 0;
+    padding: 0;
+    counter-reset: step-counter;
+}
+
+.steps li {
+    background: var(--color-surface);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    display: grid;
+    gap: 12px;
+    position: relative;
+}
+
+.steps li::before {
+    counter-increment: step-counter;
+    content: counter(step-counter);
+    position: absolute;
+    top: 24px;
+    right: 24px;
+    font-weight: 700;
+    color: rgba(6, 28, 88, 0.16);
+    font-size: 48px;
+}
+
+.section--accent .steps li {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.growth {
+    display: grid;
+    gap: 32px;
+    align-items: center;
+}
+
+.growth__list {
+    margin: 0;
+    padding-left: 20px;
+    color: rgba(255, 255, 255, 0.88);
+}
+
+.growth__visual img {
+    box-shadow: var(--shadow-soft);
+}
+
+.resources {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.resource-card {
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    background: #ffffff;
+    display: grid;
+    gap: 16px;
+    box-shadow: var(--shadow-soft);
+}
+
+.resource-card--cta {
+    background: var(--color-primary);
+    color: #ffffff;
+}
+
+.resource-card--cta .btn--ghost {
+    border-color: rgba(255, 255, 255, 0.48);
+    color: #ffffff;
+}
+
+.ai {
+    display: grid;
+    gap: 32px;
+    align-items: start;
+}
+
+.ai__card {
+    background: #ffffff;
+    color: var(--color-deep);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    box-shadow: var(--shadow-soft);
+}
+
+.ai__card ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.ai__note {
+    font-size: 14px;
+    color: var(--color-muted);
+}
+
+.partners {
+    display: grid;
+    gap: 32px;
+}
+
+.partners__grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.partners__grid article {
+    background: var(--color-surface);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    display: grid;
+    gap: 12px;
+}
+
+.faq__list {
+    display: grid;
+    gap: 12px;
+}
+
+.faq__list details {
+    background: #ffffff;
+    border-radius: var(--radius-lg);
+    padding: 20px 24px;
+    box-shadow: var(--shadow-soft);
+}
+
+.faq__list summary {
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.trial {
+    color: #ffffff;
+}
+
+.trial__layout {
+    display: grid;
+    gap: 32px;
+}
+
+.trial__content .contact-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 0;
+    color: #ffffff;
+}
+
+.trial__form {
+    background: #ffffff;
+    color: var(--color-deep);
+    border-radius: var(--radius-lg);
+    padding: 32px;
+    box-shadow: var(--shadow-soft);
+    display: grid;
+    gap: 16px;
+}
+
+.form-group {
+    display: grid;
+    gap: 8px;
+}
+
+label {
+    font-weight: 600;
+}
+
+input, select, textarea {
+    border: 1px solid rgba(6, 28, 88, 0.16);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font: inherit;
+}
+
+textarea {
+    resize: vertical;
+}
+
+.form__note {
+    font-size: 13px;
+    color: var(--color-muted);
+}
+
+.form__status {
+    font-size: 14px;
+    min-height: 20px;
+}
+
+.about {
+    display: grid;
+    gap: 32px;
+}
+
+.about__grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.footer {
+    background: #02092b;
+    color: rgba(255, 255, 255, 0.88);
+    padding-top: 64px;
+}
+
+.footer__layout {
+    display: grid;
+    gap: 32px;
+}
+
+.footer__brand {
+    display: grid;
+    gap: 16px;
+}
+
+.footer__social {
+    display: flex;
+    gap: 16px;
+}
+
+.footer__info {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.footer__info ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.footer__legal {
+    margin-top: 48px;
+    background: #01061a;
+    padding: 16px 0;
+    font-size: 14px;
+}
+
+.footer__legal__inner {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.back-to-top {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    background: var(--color-primary);
+    color: #ffffff;
+    border: none;
+    border-radius: 999px;
+    width: 48px;
+    height: 48px;
+    display: grid;
+    place-items: center;
+    box-shadow: var(--shadow-soft);
+    cursor: pointer;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(16px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.back-to-top.show {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(2, 9, 43, 0.56);
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    padding: 24px;
+}
+
+.modal[aria-hidden="false"] {
+    visibility: visible;
+    opacity: 1;
+}
+
+.modal__backdrop {
+    position: absolute;
+    inset: 0;
+}
+
+.modal__content {
+    position: relative;
+    background: #ffffff;
+    color: var(--color-deep);
+    padding: 32px;
+    border-radius: var(--radius-lg);
+    max-width: 960px;
+    width: min(960px, 100%);
+    max-height: 90vh;
+    overflow: auto;
+    display: grid;
+    gap: 16px;
+}
+
+.modal__close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    border: none;
+    background: rgba(6, 28, 88, 0.08);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    font-size: 18px;
+    cursor: pointer;
+}
+
+.map img {
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+}
+
+@media (max-width: 960px) {
+    .nav-links {
+        position: absolute;
+        inset: 72px 16px auto 16px;
+        flex-direction: column;
+        align-items: stretch;
+        background: #ffffff;
+        padding: 24px;
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-soft);
+        transform: translateY(-16px);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    .nav-links.show {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateY(0);
+    }
+
+    .nav-cta {
+        display: block;
+    }
+
+    .nav-toggle {
+        display: inline-flex;
+    }
+
+    .hero__layout {
+        grid-template-columns: 1fr;
+    }
+
+    .hero__meta {
+        grid-template-columns: 1fr;
+    }
+
+    .metrics__item {
+        flex: 1 1 calc(50% - 16px);
+    }
+
+    .proof {
+        grid-template-columns: 1fr;
+    }
+
+    .growth {
+        grid-template-columns: 1fr;
+    }
+
+    .trial__layout {
+        grid-template-columns: 1fr;
+    }
+
+    .ai {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (min-width: 961px) {
+    .hero__layout {
+        grid-template-columns: 1.1fr 1fr;
+    }
+
+    .hero__media {
+        grid-template-columns: 1fr;
+    }
+
+    .hero__gallery {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .hero__video {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .hero__meta {
+        grid-template-columns: auto 1fr;
+        gap: 24px;
+    }
+
+    .metrics {
+        justify-content: flex-start;
+    }
+
+    .proof {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .growth {
+        grid-template-columns: 1fr 0.9fr;
+    }
+
+    .trial__layout {
+        grid-template-columns: 0.9fr 1fr;
+        align-items: start;
+    }
+
+    .ai {
+        grid-template-columns: 1.1fr 0.9fr;
+    }
+}
+
+@media (max-width: 640px) {
+    .section {
+        padding: 64px 0;
+    }
+
+    .section__header {
+        margin-bottom: 32px;
+    }
+
+    .metrics__item {
+        min-width: calc(50% - 8px);
+    }
+
+    .plan {
+        padding: 24px;
+    }
+
+    .footer__legal__inner {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+.nav-toggle.is-active span:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+}
+
+.nav-toggle.is-active span:nth-child(2) {
+    opacity: 0;
+}
+
+.nav-toggle.is-active span:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+}

--- a/assets/img/growth-report.svg
+++ b/assets/img/growth-report.svg
@@ -1,0 +1,26 @@
+<svg width="960" height="640" viewBox="0 0 960 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="960" height="640" rx="32" fill="#FFFFFF"/>
+  <rect x="40" y="40" width="880" height="80" rx="16" fill="#0B4FFF" opacity="0.08"/>
+  <text x="80" y="92" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="28" font-weight="600" fill="#061C58">成长档案 · S2 节奏掌控阶段</text>
+  <text x="80" y="132" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="16" fill="#5C6784">更新时间：2024-05-12</text>
+  <rect x="40" y="160" width="280" height="440" rx="24" fill="#F5F7FF"/>
+  <text x="72" y="208" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" fill="#061C58">阶段指标</text>
+  <text x="72" y="244" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="14" fill="#2F3A5C">节奏配合</text>
+  <rect x="72" y="252" width="200" height="16" rx="8" fill="#D9E4FF"/>
+  <rect x="72" y="252" width="160" height="16" rx="8" fill="#0B4FFF"/>
+  <text x="72" y="300" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="14" fill="#2F3A5C">体能耐力</text>
+  <rect x="72" y="308" width="200" height="16" rx="8" fill="#D9E4FF"/>
+  <rect x="72" y="308" width="140" height="16" rx="8" fill="#0B4FFF"/>
+  <text x="72" y="356" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="14" fill="#2F3A5C">核心稳定</text>
+  <rect x="72" y="364" width="200" height="16" rx="8" fill="#D9E4FF"/>
+  <rect x="72" y="364" width="120" height="16" rx="8" fill="#0B4FFF"/>
+  <text x="72" y="412" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="14" fill="#2F3A5C">段位积分</text>
+  <rect x="72" y="420" width="200" height="16" rx="8" fill="#D9E4FF"/>
+  <rect x="72" y="420" width="184" height="16" rx="8" fill="#FF7A45"/>
+  <rect x="360" y="160" width="560" height="208" rx="24" fill="#FDF4EE"/>
+  <text x="392" y="204" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" fill="#B25016">阶段亮点</text>
+  <text x="392" y="240" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="14" fill="#6F4330">· 60 秒单摇次数达 128 次，提升 32%\n· 花式组合“交叉 + 反交叉”完成度 4.5/5\n· 家庭作业完成率 92%</text>
+  <rect x="360" y="388" width="560" height="212" rx="24" fill="#F5F7FF"/>
+  <text x="392" y="432" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="18" font-weight="600" fill="#061C58">教练建议</text>
+  <text x="392" y="468" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="14" fill="#2F3A5C">1. 每周 3 次 8 分钟节拍器练习，节奏控制在 160 BPM。\n2. 结合平板支撑 + 侧支撑，每次 3 组，强化核心稳定。\n3. 周末参加社群挑战赛，积累舞台经验。</text>
+</svg>

--- a/assets/img/logo.svg
+++ b/assets/img/logo.svg
@@ -1,0 +1,7 @@
+<svg width="160" height="48" viewBox="0 0 160 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="2" width="156" height="44" rx="12" fill="#0B4FFF" stroke="#061C58" stroke-width="4"/>
+  <path d="M32 16c4.418 0 8 3.582 8 8s-3.582 8-8 8-8-3.582-8-8 3.582-8 8-8z" fill="#FFFFFF"/>
+  <path d="M28 24.5c2.5-2 5-2 7.5 0" stroke="#0B4FFF" stroke-width="2" stroke-linecap="round"/>
+  <path d="M52 18h10l-5 16h-10L52 18z" fill="#ffffff"/>
+  <text x="72" y="29" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="16" font-weight="600" fill="#FFFFFF">我们跳绳</text>
+</svg>

--- a/assets/img/map-placeholder.svg
+++ b/assets/img/map-placeholder.svg
@@ -1,0 +1,6 @@
+<svg width="280" height="160" viewBox="0 0 280 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="280" height="160" rx="16" fill="#F5F7FF"/>
+  <path d="M40 60c0-22.091 17.909-40 40-40h120c22.091 0 40 17.909 40 40v40c0 22.091-17.909 40-40 40H80c-22.091 0-40-17.909-40-40V60z" fill="#E1E8FF"/>
+  <path d="M140 48c-17.673 0-32 14.327-32 32 0 18.667 24 44 29.245 49.245a4 4 0 0 0 5.51 0C148 124 172 98.667 172 80c0-17.673-14.327-32-32-32zm0 44a12 12 0 1 1 0-24 12 12 0 0 1 0 24z" fill="#0B4FFF"/>
+  <text x="140" y="148" text-anchor="middle" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="16" fill="#061C58">张江运动中心</text>
+</svg>

--- a/assets/img/og-cover.svg
+++ b/assets/img/og-cover.svg
@@ -1,0 +1,17 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B4FFF"/>
+      <stop offset="1" stop-color="#061C58"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#bg)"/>
+  <text x="120" y="180" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="52" font-weight="700" fill="#ffffff">我们跳绳体能培训</text>
+  <text x="120" y="244" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="28" fill="rgba(255,255,255,0.88)">阶段式训练 × 可视化档案 × 家校协同</text>
+  <rect x="120" y="280" width="220" height="6" rx="3" fill="#FF7A45"/>
+  <text x="120" y="360" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="22" fill="rgba(255,255,255,0.88)">预约体验课 · 到店评估 · 定制成长计划</text>
+  <rect x="760" y="100" width="320" height="430" rx="32" fill="rgba(255,255,255,0.12)"/>
+  <circle cx="840" cy="200" r="88" fill="#ffffff" opacity="0.12"/>
+  <text x="800" y="420" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#ffffff">+92%</text>
+  <text x="800" y="464" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="20" fill="rgba(255,255,255,0.8)">体验课好评率</text>
+</svg>

--- a/assets/img/qr-weapp.svg
+++ b/assets/img/qr-weapp.svg
@@ -1,0 +1,17 @@
+<svg width="152" height="152" viewBox="0 0 152 152" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="152" height="152" rx="16" fill="#F5F7FF"/>
+  <rect x="20" y="20" width="16" height="16" fill="#0B4FFF"/>
+  <rect x="116" y="20" width="16" height="16" fill="#0B4FFF"/>
+  <rect x="20" y="116" width="16" height="16" fill="#0B4FFF"/>
+  <rect x="116" y="116" width="16" height="16" fill="#0B4FFF"/>
+  <rect x="44" y="44" width="64" height="64" fill="#0B4FFF" opacity="0.12"/>
+  <rect x="60" y="60" width="32" height="32" fill="#0B4FFF" opacity="0.24"/>
+  <rect x="68" y="68" width="16" height="16" fill="#0B4FFF"/>
+  <rect x="28" y="52" width="12" height="12" fill="#0B4FFF"/>
+  <rect x="44" y="92" width="12" height="12" fill="#0B4FFF"/>
+  <rect x="96" y="44" width="12" height="12" fill="#0B4FFF"/>
+  <rect x="108" y="80" width="12" height="12" fill="#0B4FFF"/>
+  <rect x="72" y="112" width="12" height="12" fill="#0B4FFF"/>
+  <circle cx="76" cy="24" r="6" fill="#ff7a45"/>
+  <text x="76" y="140" text-anchor="middle" font-family="'Manrope', 'Segoe UI', Arial, sans-serif" font-size="14" fill="#061C58">微信扫码</text>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,202 @@
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav-links');
+const backToTop = document.querySelector('.back-to-top');
+const modalTriggers = document.querySelectorAll('[data-modal-target]');
+const modalDismiss = document.querySelectorAll('[data-modal-dismiss]');
+const forms = document.querySelectorAll('form');
+const trialForm = document.getElementById('trial-form');
+const trialStatus = trialForm ? trialForm.querySelector('.form__status') : null;
+let activeModal = null;
+
+const toggleNav = () => {
+    if (!navToggle || !navLinks) return;
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
+    navToggle.classList.toggle('is-active');
+    navLinks.classList.toggle('show');
+};
+
+navToggle?.addEventListener('click', toggleNav);
+
+navLinks?.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+        if (window.innerWidth <= 960) {
+            navLinks.classList.remove('show');
+            navToggle?.setAttribute('aria-expanded', 'false');
+            navToggle?.classList.remove('is-active');
+        }
+    });
+});
+
+const handleBackToTop = () => {
+    if (!backToTop) return;
+    if (window.scrollY > 320) {
+        backToTop.classList.add('show');
+    } else {
+        backToTop.classList.remove('show');
+    }
+};
+
+backToTop?.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+});
+
+if (backToTop) {
+    window.addEventListener('scroll', handleBackToTop);
+    handleBackToTop();
+}
+
+const openModal = (selector) => {
+    const modal = document.querySelector(selector);
+    if (!modal) return;
+    activeModal = modal;
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+    const focusable = modal.querySelector('button, [href], input, select, textarea');
+    focusable?.focus();
+};
+
+const closeModal = () => {
+    if (!activeModal) return;
+    activeModal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+    activeModal = null;
+};
+
+modalTriggers.forEach((trigger) => {
+    trigger.addEventListener('click', () => {
+        const target = trigger.getAttribute('data-modal-target');
+        if (!target) return;
+        openModal(target);
+    });
+});
+
+modalDismiss.forEach((dismiss) => {
+    dismiss.addEventListener('click', () => {
+        const modal = dismiss.closest('.modal');
+        if (modal) {
+            activeModal = modal;
+        }
+        closeModal();
+    });
+});
+
+document.querySelectorAll('.modal').forEach((modal) => {
+    modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            activeModal = modal;
+            closeModal();
+        }
+    });
+});
+
+document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && activeModal) {
+        closeModal();
+    }
+});
+
+const analyticsElements = document.querySelectorAll('[data-track]');
+analyticsElements.forEach((element) => {
+    element.addEventListener('click', () => {
+        const label = element.getAttribute('data-track-label') || 'unknown';
+        const type = element.getAttribute('data-track');
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+            event: 'cta_click',
+            trackType: type,
+            trackLabel: label,
+        });
+    });
+});
+
+const parseUTM = () => {
+    const params = new URLSearchParams(window.location.search);
+    return {
+        source: params.get('utm_source') || '',
+        medium: params.get('utm_medium') || '',
+        campaign: params.get('utm_campaign') || '',
+    };
+};
+
+const fillUTMFields = () => {
+    if (!trialForm) return;
+    const utm = parseUTM();
+    trialForm.querySelector('[name="utm_source"]').value = utm.source;
+    trialForm.querySelector('[name="utm_medium"]').value = utm.medium;
+    trialForm.querySelector('[name="utm_campaign"]').value = utm.campaign;
+};
+
+fillUTMFields();
+
+const submitTrialForm = async (event) => {
+    event.preventDefault();
+    if (!trialForm) return;
+    const data = new FormData(trialForm);
+
+    try {
+        const response = await fetch(trialForm.action, {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+            },
+            body: data,
+        });
+
+        if (response.ok) {
+            trialForm.reset();
+            fillUTMFields();
+            if (trialStatus) {
+                trialStatus.textContent = '预约成功提交，我们将在 24 小时内联系您确认。';
+                trialStatus.style.color = 'var(--color-primary)';
+            }
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({ event: 'form_submit', formId: 'trial' });
+        } else {
+            throw new Error('网络异常');
+        }
+    } catch (error) {
+        if (trialStatus) {
+            trialStatus.textContent = '提交失败，请稍后重试或直接拨打 400-800-1234。';
+            trialStatus.style.color = 'var(--color-accent)';
+        }
+    }
+};
+
+trialForm?.addEventListener('submit', submitTrialForm);
+
+forms.forEach((form) => {
+    form.addEventListener('submit', () => {
+        const label = form.getAttribute('id') || 'form';
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({ event: 'form_attempt', formId: label });
+    });
+});
+
+const observeLazyMedia = () => {
+    const media = document.querySelectorAll('img[loading="lazy"]');
+    if (!('IntersectionObserver' in window)) {
+        media.forEach((el) => {
+            if (el.dataset && el.dataset.src) {
+                el.src = el.dataset.src;
+            }
+        });
+        return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                const target = entry.target;
+                if (target.dataset && target.dataset.src) {
+                    target.src = target.dataset.src;
+                }
+                observer.unobserve(target);
+            }
+        });
+    });
+
+    media.forEach((el) => observer.observe(el));
+};
+
+observeLazyMedia();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,662 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="我们跳绳体能培训中心，提供阶段式跳绳与体能课程、成长档案与家校协同方案，帮助孩子在安全环境中快速建立自信与体能。">
+    <link rel="canonical" href="https://www.womentiasheng.com/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="我们跳绳 · 儿童跳绳体能培训">
+    <meta property="og:description" content="阶段式训练 × 可视化档案 × 家校协同，10 秒完成预约体验课或打开小程序。">
+    <meta property="og:url" content="https://www.womentiasheng.com/">
+    <meta property="og:image" content="https://www.womentiasheng.com/assets/img/og-cover.svg">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="theme-color" content="#0b4fff">
+    <title>我们跳绳 · 体能培训</title>
+    <link rel="icon" type="image/svg+xml" href="assets/img/logo.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="sitemap" type="application/xml" href="sitemap.xml">
+    <script defer src="assets/js/main.js"></script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "我们跳绳体能培训中心",
+        "url": "https://www.womentiasheng.com/",
+        "logo": "https://www.womentiasheng.com/assets/img/logo.svg",
+        "sameAs": [
+            "https://weixin.qq.com/",
+            "https://www.douyin.com/",
+            "https://www.xiaohongshu.com/"
+        ],
+        "contactPoint": {
+            "@type": "ContactPoint",
+            "telephone": "+86-400-800-1234",
+            "contactType": "customer service",
+            "areaServed": "CN",
+            "availableLanguage": ["zh-CN"]
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        "name": "我们跳绳体能培训中心",
+        "image": "https://images.unsplash.com/photo-1526401485004-46910ecc8e51?auto=format&fit=crop&w=1200&q=80",
+        "@id": "https://www.womentiasheng.com/",
+        "url": "https://www.womentiasheng.com/",
+        "telephone": "+86-400-800-1234",
+        "priceRange": "¥¥",
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "上海市浦东新区张江路88号运动中心3层",
+            "addressLocality": "上海市",
+            "postalCode": "200120",
+            "addressCountry": "CN"
+        },
+        "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": 31.203444,
+            "longitude": 121.602082
+        },
+        "openingHoursSpecification": [{
+            "@type": "OpeningHoursSpecification",
+            "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+            "opens": "09:00",
+            "closes": "21:00"
+        }],
+        "sameAs": [
+            "https://mp.weixin.qq.com/",
+            "https://v.qq.com/"
+        ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "体验课如何预约？",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "填写官网预约表单或扫描小程序码，选择时间后提交即可，顾问将在24小时内确认。"
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "课程安全如何保障？",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "训练区采用防滑地胶与智能护具，全程持证教练1:6陪练，并配备AED与医疗箱。"
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "如果孩子请假或不满意怎么办？",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "首月不满意可退，常规班支持24小时前请假顺延，特殊情况可申请冻结。"
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "家长可以在现场陪同吗？",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "可以。我们设有透明休息区与直播回看，方便家长了解训练过程。"
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "是否提供B端合作方案？",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "提供面向学校、场馆、机构的合作落地方案，可获取课程SOP、教练培训与品牌共建支持。"
+                }
+            }
+        ]
+    }
+    </script>
+</head>
+<body>
+    <a class="skip-link" href="#hero">跳到主要内容</a>
+    <header class="site-header" id="top">
+        <div class="container">
+            <nav class="navbar" aria-label="主导航">
+                <a href="#hero" class="logo" aria-label="我们跳绳官网">
+                    <img src="assets/img/logo.svg" alt="我们跳绳 Logo" width="120" height="32">
+                </a>
+                <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu" aria-label="打开导航菜单">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+                <ul class="nav-links" id="primary-menu">
+                    <li><a href="#hero">首页</a></li>
+                    <li><a href="#pricing">课程与价格</a></li>
+                    <li><a href="#growth">学员成长</a></li>
+                    <li><a href="#trial">预约体验课</a></li>
+                    <li><a href="#resources">家长资源</a></li>
+                    <li><a href="#ai-coach">AI 教练</a></li>
+                    <li><a href="#partners">合作洽谈</a></li>
+                    <li><a href="#about">关于我们</a></li>
+                    <li class="nav-cta"><a class="btn btn--primary" href="#trial" data-track="cta" data-track-label="nav_primary_cta">预约体验课</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section id="hero" class="hero section section--tight">
+            <div class="container hero__layout">
+                <div class="hero__content">
+                    <p class="eyebrow">阶段式训练 × 可视化档案 × 家校协同</p>
+                    <h1>让孩子用跳绳，建立自信与体能的「成长系统」</h1>
+                    <p class="lead">围绕“搜索/分享 → 官网 → 小程序/预约 → 到店/成单 → App 留存”的闭环，我们用 10 秒解释清楚方法论与第一步动作。</p>
+                    <div class="hero__actions">
+                        <a class="btn btn--primary" href="#trial" data-track="cta" data-track-label="hero_trial">预约 45 分钟体验课</a>
+                        <a class="btn btn--ghost" href="https://weixin.qq.com/" target="_blank" rel="noopener" data-track="cta" data-track-label="hero_miniprogram">打开小程序</a>
+                    </div>
+                    <div class="hero__promises">
+                        <span>首月不满意可退</span>
+                        <span>安全第一</span>
+                        <span>教练专业持证</span>
+                    </div>
+                    <div class="hero__meta">
+                        <div class="hero__qr">
+                            <img src="assets/img/qr-weapp.svg" width="152" height="152" alt="微信小程序码" loading="lazy">
+                            <p>扫码 2 秒开启随堂看板<br>适配 iOS / Android</p>
+                        </div>
+                        <ul class="metrics" role="list">
+                            <li class="metrics__item">
+                                <span class="metrics__value">92%</span>
+                                <span class="metrics__label">体验课好评率</span>
+                            </li>
+                            <li class="metrics__item">
+                                <span class="metrics__value">30,000+</span>
+                                <span class="metrics__label">累计课程记录</span>
+                            </li>
+                            <li class="metrics__item">
+                                <span class="metrics__value">12 城市</span>
+                                <span class="metrics__label">校区同步上线</span>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="hero__media">
+                    <div class="hero__gallery">
+                        <figure>
+                            <img src="https://images.unsplash.com/photo-1603080825429-4dc145a28747?auto=format&fit=crop&w=900&q=80" alt="教练带领儿童进行跳绳热身训练" loading="lazy" width="320" height="200">
+                        </figure>
+                        <figure>
+                            <img src="https://images.unsplash.com/photo-1526401485004-46910ecc8e51?auto=format&fit=crop&w=900&q=80" alt="少年在专业场馆进行跳绳测试" loading="lazy" width="320" height="200">
+                        </figure>
+                        <figure>
+                            <img src="https://images.unsplash.com/photo-1617957743090-0fed0f3a2f25?auto=format&fit=crop&w=900&q=80" alt="教练现场纠正儿童跳绳动作" loading="lazy" width="320" height="200">
+                        </figure>
+                    </div>
+                    <div class="hero__video">
+                        <video class="video" controls preload="metadata" poster="https://images.unsplash.com/photo-1529158062015-cad636e69505?auto=format&fit=crop&w=1200&q=80" aria-label="15 秒训练掠影" muted playsinline>
+                            <source src="https://cdn.coverr.co/videos/coverr-jumping-rope-1640176155564?download=1" type="video/mp4">
+                            您的浏览器不支持视频播放。
+                        </video>
+                        <p class="video__caption">15 秒看懂真实课堂氛围</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="why" class="section section--light">
+            <div class="container">
+                <header class="section__header">
+                    <span class="eyebrow">为什么有效</span>
+                    <h2>科学训练 + 成长树与积分体系 + 家校协同</h2>
+                    <p>我们把跳绳拆解为速度、耐力、灵敏与核心四个动作要素，以周期化训练搭配 AI 教练建议，形成完整的成长闭环。</p>
+                </header>
+                <div class="grid grid--three">
+                    <article class="tile">
+                        <h3>周期化训练</h3>
+                        <p>依据学员阶段划分 S1-S4 阶段，4 周为一周期，结合动作拆分、力量准备、组合巩固三步走。</p>
+                        <ul>
+                            <li>速度 × 节奏：通过节拍器与高频短组训练</li>
+                            <li>耐力 × 心肺：间歇式 HIIT + 心率监测</li>
+                            <li>灵敏 × 核心：敏捷梯、稳定性训练穿插</li>
+                        </ul>
+                    </article>
+                    <article class="tile">
+                        <h3>成长树可视化</h3>
+                        <p>课堂数据实时上传 App，生成成长里程碑，积分兑换徽章，激励孩子主动练习。</p>
+                        <ul>
+                            <li>阶段标准：S1 基础配合 → S4 竞技花式</li>
+                            <li>每课反馈：动作评分 + 视频回放</li>
+                            <li>成长档案：出勤率、达成度一图即懂</li>
+                        </ul>
+                    </article>
+                    <article class="tile">
+                        <h3>家校协同</h3>
+                        <p>教练、家长、学校三方共建成长档案。周报邮件 + 班级群跟进，确保反馈及时。</p>
+                        <ul>
+                            <li>家长课堂旁听 &amp; 在线直播回放</li>
+                            <li>学校体测标准对齐，阶段测评互通</li>
+                            <li>家庭作业包：5 分钟即可完成的陪练</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="pricing" class="section">
+            <div class="container">
+                <header class="section__header">
+                    <span class="eyebrow">课程与价格</span>
+                    <h2>三大套餐满足不同阶段需求</h2>
+                    <p>价格透明、规则明确，满足家长对“安全吗？有效吗？多少钱？什么时候上课？”的四大关切。</p>
+                </header>
+                <div class="pricing-grid">
+                    <article class="plan plan--highlight">
+                        <span class="plan__badge">低门槛</span>
+                        <h3>体验课 · 45 分钟</h3>
+                        <p class="plan__price">¥99 / 次</p>
+                        <ul>
+                            <li>专项体能评估 + 动作纠错</li>
+                            <li>与教练 1:1 沟通成长目标</li>
+                            <li>体验后 48 小时内报名立减 ¥200</li>
+                        </ul>
+                        <a class="btn btn--primary" href="#trial" data-track="cta" data-track-label="pricing_trial">立即预约</a>
+                    </article>
+                    <article class="plan">
+                        <h3>常规成长班</h3>
+                        <p class="plan__price">¥2,880 / 12 次</p>
+                        <ul>
+                            <li>每周 1 次，小班 1:6</li>
+                            <li>成长档案 + 家校共育周报</li>
+                            <li>缺课 24 小时前可顺延</li>
+                        </ul>
+                        <a class="btn btn--ghost" href="#trial" data-track="cta" data-track-label="pricing_regular">咨询顾问</a>
+                    </article>
+                    <article class="plan">
+                        <h3>提升竞赛班</h3>
+                        <p class="plan__price">¥4,680 / 12 次</p>
+                        <ul>
+                            <li>双教练编组，竞技套路拆解</li>
+                            <li>专项体测 + 每月视频分析</li>
+                            <li>全国段位测评报名优先</li>
+                        </ul>
+                        <a class="btn btn--ghost" href="#trial" data-track="cta" data-track-label="pricing_pro">获取方案</a>
+                    </article>
+                </div>
+                <p class="fine-print">* 所有课程均含保险与训练装备租借；支持花呗/信用卡分期。</p>
+            </div>
+        </section>
+
+        <section id="proof" class="section section--light">
+            <div class="container proof">
+                <div class="proof__summary">
+                    <header class="section__header section__header--left">
+                        <span class="eyebrow">真实证明</span>
+                        <h2>数据、家长口碑、合作单位三重背书</h2>
+                        <p>核心 KPI 实时追踪：首屏 CTA 点击率、预约转化、到店率、成交率、小程序回流率。</p>
+                    </header>
+                    <dl class="kpi">
+                        <div>
+                            <dt>预约转化率</dt>
+                            <dd>28.6%</dd>
+                        </div>
+                        <div>
+                            <dt>到店率</dt>
+                            <dd>64.2%</dd>
+                        </div>
+                        <div>
+                            <dt>体验后续费</dt>
+                            <dd>32.4%</dd>
+                        </div>
+                        <div>
+                            <dt>小程序点击</dt>
+                            <dd>13.1%</dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class="proof__details">
+                    <div class="testimonials" aria-label="家长评价">
+                        <article>
+                            <blockquote>
+                                “两个月从 30 秒 40 下提升到 90 下，孩子明显自信了，作业专注度也提升。”
+                            </blockquote>
+                            <p class="testimonial__meta">— 五年级家长（匿名）</p>
+                        </article>
+                        <article>
+                            <blockquote>
+                                “成长档案每周更新，家长群里教练都会提醒家庭练习，感觉非常专业且省心。”
+                            </blockquote>
+                            <p class="testimonial__meta">— 二年级家长（匿名）</p>
+                        </article>
+                    </div>
+                    <div class="logos" aria-label="合作单位">
+                        <img src="assets/img/logo.svg" alt="虹桥实验小学" width="128" height="32" loading="lazy">
+                        <img src="assets/img/logo.svg" alt="星河体育中心" width="128" height="32" loading="lazy">
+                        <img src="assets/img/logo.svg" alt="浦东青少年宫" width="128" height="32" loading="lazy">
+                        <img src="assets/img/logo.svg" alt="橙子体适能" width="128" height="32" loading="lazy">
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="journey" class="section">
+            <div class="container">
+                <header class="section__header">
+                    <span class="eyebrow">如何开始</span>
+                    <h2>3 步完成体验 → 评估 → 个性化计划</h2>
+                </header>
+                <ol class="steps">
+                    <li>
+                        <h3>1. 在线预约</h3>
+                        <p>填写官网表单或扫描二维码，选择时间并留下联系方式。</p>
+                    </li>
+                    <li>
+                        <h3>2. 到店体验</h3>
+                        <p>45 分钟深度体验 + 专项评测，家长全程可旁听。</p>
+                    </li>
+                    <li>
+                        <h3>3. 定制成长计划</h3>
+                        <p>依据评测结果输出 S 阶段成长路线，App 同步训练清单。</p>
+                    </li>
+                </ol>
+            </div>
+        </section>
+
+        <section id="growth" class="section section--accent">
+            <div class="container growth">
+                <div class="growth__content">
+                    <header class="section__header section__header--left">
+                        <span class="eyebrow">成长档案样张</span>
+                        <h2>一图看懂阶段、积分、出勤与目标</h2>
+                        <p>学员档案自动记录课堂表现、家庭练习、段位进阶状态。家长与教练可即时查看，校方可导出报告。</p>
+                        <ul class="growth__list">
+                            <li>S 阶段目标清晰：S1 基础配合、S2 节奏掌控、S3 花式挑战、S4 竞技应战。</li>
+                            <li>积分激励：达成任务获得星徽，可兑换营期、装备等福利。</li>
+                            <li>家校共育：支持导出 PDF 与体测标准对接，便于学校备案。</li>
+                        </ul>
+                        <button class="btn btn--light" type="button" data-modal-target="#report-modal" data-track="cta" data-track-label="growth_preview">放大查看样张</button>
+                    </header>
+                </div>
+                <div class="growth__visual">
+                    <img src="assets/img/growth-report.svg" alt="成长档案样张预览" width="520" height="360" loading="lazy">
+                </div>
+            </div>
+        </section>
+
+        <section id="resources" class="section">
+            <div class="container">
+                <header class="section__header">
+                    <span class="eyebrow">家长资源</span>
+                    <h2>家长必读与成长体系权威解读</h2>
+                    <p>永续内容帮助家长持续理解跳绳训练价值，同时引导关注公众号、加入社群。</p>
+                </header>
+                <div class="resources">
+                    <article class="resource-card">
+                        <h3>孩子几岁适合开始跳绳训练？不同阶段练什么</h3>
+                        <p>从感统启蒙到竞技进阶，梳理 4-12 岁训练重点与注意事项。</p>
+                        <a href="#" data-track="resource" data-track-label="article_age">阅读长文</a>
+                    </article>
+                    <article class="resource-card">
+                        <h3>如何用“成长档案”激励孩子：积分与阶段的科学性</h3>
+                        <p>拆解积分体系设计逻辑，分享家长在家落地的四步方法。</p>
+                        <a href="#" data-track="resource" data-track-label="article_archive">阅读长文</a>
+                    </article>
+                    <aside class="resource-card resource-card--cta">
+                        <h3>学习资源一键获取</h3>
+                        <p>关注公众号 / 加入社群 / 订阅视频号，获取家庭训练包与周打卡提醒。</p>
+                        <div class="resource-card__actions">
+                            <a class="btn btn--ghost" href="https://mp.weixin.qq.com/" target="_blank" rel="noopener" data-track="cta" data-track-label="resources_wechat">关注公众号</a>
+                            <a class="btn btn--ghost" href="https://www.feishu.cn/" target="_blank" rel="noopener" data-track="cta" data-track-label="resources_group">加入社群</a>
+                        </div>
+                    </aside>
+                </div>
+            </div>
+        </section>
+
+        <section id="ai-coach" class="section section--light">
+            <div class="container ai">
+                <div>
+                    <header class="section__header section__header--left">
+                        <span class="eyebrow">AI 教练</span>
+                        <h2>随时提问，获得专属训练建议</h2>
+                        <p>AI 教练训练 Q&amp;A 支持 7x24 小时在线，涵盖动作纠错、家庭训练、营养恢复等主题。</p>
+                    </header>
+                    <a class="btn btn--primary" href="https://chat.openai.com/" target="_blank" rel="noopener" data-track="cta" data-track-label="ai_chat">打开 AI 教练</a>
+                    <p class="ai__note">* 企业可接入定制模型，结合学员档案实现个性化教学反馈。</p>
+                </div>
+                <div class="ai__card">
+                    <h3>推荐问法</h3>
+                    <ul>
+                        <li>“孩子跳绳左脚总是不配合，如何纠正？”</li>
+                        <li>“S2 阶段家庭训练，一周安排几次？”</li>
+                        <li>“段位测评前一周怎么准备？”</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="partners" class="section">
+            <div class="container partners">
+                <header class="section__header section__header--left">
+                    <span class="eyebrow">合作洽谈</span>
+                    <h2>面向学校 / 场馆 / 机构的全链路合作方案</h2>
+                    <p>标准化落地流程 + 数据合规体系，支持校园课后服务、社群营地、体测提升等多种场景。</p>
+                </header>
+                <div class="partners__grid">
+                    <article>
+                        <h3>合作模式</h3>
+                        <ul>
+                            <li>To School：校内社团 &amp; 课后服务</li>
+                            <li>To Gym：场馆联合运营</li>
+                            <li>To Club：素质教育机构共建</li>
+                        </ul>
+                    </article>
+                    <article>
+                        <h3>落地流程</h3>
+                        <ul>
+                            <li>需求诊断 → 方案共创 → 教练培训</li>
+                            <li>上线运营 → 数据复盘 → 品牌共建</li>
+                            <li>提供安全责任与保险支持</li>
+                        </ul>
+                    </article>
+                    <article>
+                        <h3>物料下载</h3>
+                        <ul>
+                            <li><a href="#" data-track="download" data-track-label="download_pdf">中心介绍 PDF</a></li>
+                            <li><a href="#" data-track="download" data-track-label="download_deck">合作方案 Deck</a></li>
+                            <li><a href="#" data-track="download" data-track-label="download_license">资质证明</a></li>
+                        </ul>
+                    </article>
+                </div>
+                <a class="btn btn--primary" href="#trial" data-track="cta" data-track-label="partners_contact">我要与贵中心合作</a>
+            </div>
+        </section>
+
+        <section id="faq" class="section section--light">
+            <div class="container faq">
+                <header class="section__header">
+                    <span class="eyebrow">常见问题</span>
+                    <h2>精选 7 个家长最关注的问题</h2>
+                </header>
+                <div class="faq__list">
+                    <details open>
+                        <summary>体验课如何预约？</summary>
+                        <p>填写官网预约表单或扫描小程序码，选择时间后提交即可，顾问将在 24 小时内确认。</p>
+                    </details>
+                    <details>
+                        <summary>课程安全如何保障？</summary>
+                        <p>训练区采用防滑地胶与智能护具，全程持证教练 1:6 陪练，并配备 AED 与医疗箱。</p>
+                    </details>
+                    <details>
+                        <summary>如果孩子请假或不满意怎么办？</summary>
+                        <p>首月不满意可退，常规班支持 24 小时前请假顺延，特殊情况可申请冻结。</p>
+                    </details>
+                    <details>
+                        <summary>上课时间如何安排？</summary>
+                        <p>周一至周日 09:00-21:00 分时段开课，可通过小程序实时查看空位。</p>
+                    </details>
+                    <details>
+                        <summary>交通与停车方便吗？</summary>
+                        <p>中心临近地铁 2 号线张江高科站，地面停车 2 小时免费。</p>
+                    </details>
+                    <details>
+                        <summary>如何退款？</summary>
+                        <p>体验课 24 小时前取消全额退，常规班按照剩余课次核算并于 7 个工作日内退回。</p>
+                    </details>
+                    <details>
+                        <summary>是否提供 B 端合作方案？</summary>
+                        <p>提供面向学校、场馆、机构的合作落地方案，可获取课程 SOP、教练培训与品牌共建支持。</p>
+                    </details>
+                </div>
+            </div>
+        </section>
+
+        <section id="trial" class="section section--accent trial">
+            <div class="container trial__layout">
+                <div class="trial__content">
+                    <header class="section__header section__header--left">
+                        <span class="eyebrow">预约体验课</span>
+                        <h2>留下信息，24 小时内有顾问联系确认</h2>
+                        <p>我们遵循 UTM 规范追踪按钮点击、二维码曝光、表单提交，持续优化体验课转化率。</p>
+                        <div class="trial__contact">
+                            <a href="tel:4008001234" class="contact-link" data-track="contact" data-track-label="phone">电话：400-800-1234</a>
+                            <a href="https://work.weixin.qq.com/" target="_blank" rel="noopener" class="contact-link" data-track="contact" data-track-label="wechat">企业微信咨询</a>
+                        </div>
+                    </header>
+                </div>
+                <form class="trial__form" id="trial-form" action="https://formspree.io/f/mwkjarvo" method="POST">
+                    <div class="form-group">
+                        <label for="parent-name">家长姓名</label>
+                        <input type="text" id="parent-name" name="parentName" required placeholder="请输入您的姓名">
+                    </div>
+                    <div class="form-group">
+                        <label for="child-age">孩子年龄</label>
+                        <input type="number" id="child-age" name="childAge" min="3" max="16" required placeholder="如：8">
+                    </div>
+                    <div class="form-group">
+                        <label for="phone">联系电话</label>
+                        <input type="tel" id="phone" name="phone" pattern="[0-9]{11}" inputmode="numeric" required placeholder="请输入 11 位手机号">
+                    </div>
+                    <div class="form-group">
+                        <label for="campus">意向校区</label>
+                        <select id="campus" name="campus" required>
+                            <option value="">请选择</option>
+                            <option>上海 · 张江中心</option>
+                            <option>上海 · 虹桥中心</option>
+                            <option>杭州 · 钱江中心</option>
+                            <option>深圳 · 南山中心</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="time">期望上课时间</label>
+                        <input type="text" id="time" name="preferredTime" placeholder="例如：周三下午 或 周末上午">
+                    </div>
+                    <div class="form-group">
+                        <label for="note">孩子情况 / 目标</label>
+                        <textarea id="note" name="note" rows="4" placeholder="简单描述孩子的训练目标或注意事项"></textarea>
+                    </div>
+                    <input type="hidden" name="utm_source" value="">
+                    <input type="hidden" name="utm_medium" value="">
+                    <input type="hidden" name="utm_campaign" value="">
+                    <button class="btn btn--primary" type="submit" data-track="cta" data-track-label="trial_submit">提交预约信息</button>
+                    <p class="form__note">提交即代表同意《隐私政策》，我们仅用于课程服务联系。</p>
+                    <div class="form__status" role="status" aria-live="polite"></div>
+                </form>
+            </div>
+        </section>
+
+        <section id="about" class="section">
+            <div class="container about">
+                <header class="section__header section__header--left">
+                    <span class="eyebrow">关于我们</span>
+                    <h2>顶级教练团队 + 专业体能专家 + 资深教育顾问</h2>
+                    <p>我们整合体能训练专家、教育者与教练团队，结合 AI 数据工具，为孩子打造全方位的成长体验。</p>
+                </header>
+                <div class="about__grid">
+                    <article>
+                        <h3>教练团队</h3>
+                        <p>来自国家队退役运动员、体能教练、感统师资，平均教龄 6.5 年，全部通过红十字救护认证。</p>
+                    </article>
+                    <article>
+                        <h3>课程研发</h3>
+                        <p>体能专家联合儿童心理顾问设计课程，符合国家体测标准与段位体系。</p>
+                    </article>
+                    <article>
+                        <h3>家长支持</h3>
+                        <p>开设家长课堂与社群，每月一次学习型沙龙，持续打磨亲子沟通与正反馈策略。</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container footer__layout">
+            <div class="footer__brand">
+                <a href="#hero" class="logo">
+                    <img src="assets/img/logo.svg" alt="我们跳绳 Logo" width="128" height="40">
+                </a>
+                <p>让孩子用跳绳建立自信与体能的成长系统。</p>
+                <div class="footer__social">
+                    <a href="https://mp.weixin.qq.com/" target="_blank" rel="noopener">公众号</a>
+                    <a href="https://www.douyin.com/" target="_blank" rel="noopener">抖音</a>
+                    <a href="https://www.xiaohongshu.com/" target="_blank" rel="noopener">小红书</a>
+                </div>
+            </div>
+            <div class="footer__info">
+                <div>
+                    <h3>到店信息</h3>
+                    <p>上海市浦东新区张江路 88 号运动中心 3 层</p>
+                    <p>营业时间：周一至周日 09:00-21:00</p>
+                    <a class="map" href="https://uri.amap.com/marker?position=121.602082,31.203444" target="_blank" rel="noopener">
+                        <img src="assets/img/map-placeholder.svg" alt="地图位置" width="280" height="160" loading="lazy">
+                    </a>
+                </div>
+                <div>
+                    <h3>联系我们</h3>
+                    <ul>
+                        <li>电话：<a href="tel:4008001234" data-track="contact" data-track-label="footer_phone">400-800-1234</a></li>
+                        <li>邮箱：<a href="mailto:hi@womentiasheng.com" data-track="contact" data-track-label="footer_email">hi@womentiasheng.com</a></li>
+                        <li>企业微信：<a href="https://work.weixin.qq.com/" target="_blank" rel="noopener" data-track="contact" data-track-label="footer_wechat">点击添加</a></li>
+                    </ul>
+                </div>
+                <div>
+                    <h3>资料中心</h3>
+                    <ul>
+                        <li><a href="#resources">家长资源</a></li>
+                        <li><a href="#partners">合作资料包</a></li>
+                        <li><a href="#faq">常见问题</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="footer__legal">
+            <div class="container footer__legal__inner">
+                <p>© 2024 我们跳绳体能培训中心 · 沪ICP备20240001号</p>
+                <a href="robots.txt">Robots</a>
+                <a href="sitemap.xml">Sitemap</a>
+                <a href="#trial">隐私政策</a>
+            </div>
+        </div>
+    </footer>
+
+    <button class="back-to-top" type="button" aria-label="回到顶部">↑</button>
+
+    <div class="modal" id="report-modal" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="report-modal-title">
+        <div class="modal__backdrop" data-modal-dismiss></div>
+        <div class="modal__content">
+            <button class="modal__close" type="button" aria-label="关闭预览" data-modal-dismiss>×</button>
+            <h2 id="report-modal-title">成长档案样张（放大版）</h2>
+            <img src="assets/img/growth-report.svg" alt="成长档案详细样张" width="960" height="640" loading="lazy">
+        </div>
+    </div>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.womentiasheng.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.womentiasheng.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- rebuild the "我们跳绳" single-page site with a mobile-first IA covering hero, programs, proof, growth archive, AI coach, partners, FAQ, and trial form to meet the new 2.0 positioning
- implement structured SEO metadata, JSON-LD (Organization/LocalBusiness/FAQ), sitemap and robots directives plus analytics-ready CTA tracking and UTM capture
- add supporting assets including brand logo, QR card, growth report mock, and map placeholder while enhancing accessibility, lazy media loading, and Formspree-powered booking flow

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e28246697c832c950a7203b084b5d7